### PR TITLE
Refactor sgs.get function to use sgs.get_json

### DIFF
--- a/bcb/sgs/__init__.py
+++ b/bcb/sgs/__init__.py
@@ -117,17 +117,8 @@ def get(codes, start=None, end=None, last=0, multi=True, freq=None):
     """
     dfs = []
     for code in _codes(codes):
-        urd = _get_url_and_payload(code.value, start, end, last)
-        res = requests.get(urd["url"], params=urd["payload"])
-        if res.status_code != 200:
-            try:
-                res_json = json.loads(res.text)
-            except Exception:
-                res_json = {}
-            if "error" in res_json:
-                raise Exception("Download error: {}".format(res_json["error"]))
-            raise Exception("Download error: code = {}".format(code.value))
-        df = pd.read_json(StringIO(res.text))
+        text = get_json(code.value, start, end, last)
+        df = pd.read_json(StringIO(text))
         df = _format_df(df, code, freq)
         dfs.append(df)
     if len(dfs) == 1:

--- a/tests/sgs/test_series.py
+++ b/tests/sgs/test_series.py
@@ -91,19 +91,6 @@ def test_get_series():
     assert x.index[-1] == datetime.strptime("2021-01-22", "%Y-%m-%d")
 
 
-def test_get_long_series_error():
-    # Test for error when getting long series
-    try:
-        sgs.get(1, start="2000-01-01", end="2023-01-01")
-    except Exception as e:
-        assert (
-            str(e)
-            == "Download error: O sistema aceita uma janela de consulta de, no máximo, 10 anos em séries de periodicidade diária"
-        )
-    else:
-        assert False, "Expected an exception but none was raised."
-
-
 def test_json_return():
     # Test for JSON return
     x = sgs.get_json(1, last=10)


### PR DESCRIPTION
Refactor sgs.get function to use get_json for data retrieval and remove long-series error test.

Issues #24 e #21