### PR TITLE
Fix currency integration missing-symbol expectation

### DIFF
--- a/tests/integration/test_currency.py
+++ b/tests/integration/test_currency.py
@@ -23,8 +23,8 @@ def test_currency_get_symbol():
     end_date = datetime.strptime("2020-12-05", "%Y-%m-%d")
     x = currency._get_symbol("USD", start_date, end_date)
     assert isinstance(x, pd.DataFrame)
-    x = currency._get_symbol("ZAR", start_date, end_date)
-    assert x is None
+    with pytest.raises(CurrencyNotFoundError):
+        currency._get_symbol("ZAR", start_date, end_date)
     x = currency.get("USD", start_date, end_date)
     assert isinstance(x, pd.DataFrame)
     with pytest.raises(CurrencyNotFoundError):


### PR DESCRIPTION
## Summary

- Updates the live currency integration test to expect `CurrencyNotFoundError` from `_get_symbol("ZAR")`, matching the current unit-tested behavior.

Closes #30.

## Verification

- `uv run pytest tests/integration/test_currency.py -m integration`
- `uv run pytest -m integration`
- `uv run pytest -m "not integration"`
- `uv run ruff check bcb/ tests/`
- `uv run ruff format --check bcb/ tests/`
- `uv run mypy bcb/`