### PR TITLE
Use public HTTP client accessors

### DIFF
--- a/bcb/currency.py
+++ b/bcb/currency.py
@@ -15,8 +15,8 @@ import pandas as pd
 from lxml import html
 
 from bcb.http import (
-    _CLIENT,
-    _ASYNC_CLIENT,
+    get_async_client,
+    get_client,
     raise_for_request_error,
     raise_for_status,
 )
@@ -164,7 +164,7 @@ def _currency_id_list(
     )
     logger.debug(f"Fetching currency ID list from {url1}")
     try:
-        res = _CLIENT.get(url1)
+        res = get_client().get(url1)
     except httpx.HTTPError as ex:
         raise_for_request_error(ex, context="Currency ID list")
     logger.debug(
@@ -225,7 +225,7 @@ def _get_valid_currency_list(
     url2 = f"https://www4.bcb.gov.br/Download/fechamento/M{_date:%Y%m%d}.csv"
     logger.debug(f"Fetching currency list from {url2}")
     try:
-        res = _CLIENT.get(url2)
+        res = get_client().get(url2)
     except httpx.HTTPError as ex:
         # Connection error: retry same date up to 3 times
         if n >= 3:
@@ -336,7 +336,7 @@ def _fetch_symbol_response(
     url = _currency_url(cid, start_date, end_date)
     logger.debug(f"Fetching currency data for {symbol} from {url.split('?')[0]}")
     try:
-        res = _CLIENT.get(url)
+        res = get_client().get(url)
     except httpx.HTTPError as ex:
         raise_for_request_error(ex, context=f"Currency data for {symbol}")
     logger.debug(
@@ -665,7 +665,7 @@ async def _async_currency_id_list(
         "method=exibeFormularioConsultaBoletim"
     )
     try:
-        res = await _ASYNC_CLIENT.get(url1)
+        res = await get_async_client().get(url1)
     except httpx.HTTPError as ex:
         raise_for_request_error(ex, context="Currency ID list")
     raise_for_status(
@@ -696,7 +696,7 @@ async def _async_get_valid_currency_list(
 
     url2 = f"https://www4.bcb.gov.br/Download/fechamento/M{_date:%Y%m%d}.csv"
     try:
-        res = await _ASYNC_CLIENT.get(url2)
+        res = await get_async_client().get(url2)
     except httpx.HTTPError as ex:
         if n >= 3:
             raise_for_request_error(ex, context="Currency list")
@@ -759,7 +759,7 @@ async def _async_fetch_symbol_response(
     cid = await _async_get_currency_id(symbol)
     url = _currency_url(cid, start_date, end_date)
     try:
-        res = await _ASYNC_CLIENT.get(url)
+        res = await get_async_client().get(url)
     except httpx.HTTPError as ex:
         raise_for_request_error(ex, context=f"Currency data for {symbol}")
 

--- a/bcb/odata/framework.py
+++ b/bcb/odata/framework.py
@@ -11,7 +11,12 @@ import httpx
 from lxml import etree
 from typing_extensions import Self
 
-from bcb.http import _ASYNC_CLIENT, _CLIENT, raise_for_request_error, raise_for_status
+from bcb.http import (
+    get_async_client,
+    get_client,
+    raise_for_request_error,
+    raise_for_status,
+)
 from bcb.exceptions import ODataError
 
 logger = logging.getLogger(__name__)
@@ -285,7 +290,7 @@ class ODataMetadata:
     def _load_document(self) -> None:
         logger.debug(f"Fetching OData metadata from {self.url}")
         try:
-            res = _CLIENT.get(self.url)
+            res = get_client().get(self.url)
         except httpx.HTTPError as ex:
             raise_for_request_error(
                 ex, context=f"OData metadata {self.url}", error_cls=ODataError
@@ -393,7 +398,7 @@ class ODataService:
     def __init__(self, url: str) -> None:
         self.url = url
         try:
-            res = _CLIENT.get(self.url)
+            res = get_client().get(self.url)
         except httpx.HTTPError as ex:
             raise_for_request_error(
                 ex, context=f"OData service {self.url}", error_cls=ODataError
@@ -558,7 +563,7 @@ class ODataQuery:
         return json.loads(self.text())
 
     async def async_text(self) -> str:
-        """Async version of text(). Fetches OData response using _ASYNC_CLIENT."""
+        """Async version of text(). Fetches OData response using shared client."""
         params = self._build_parameters()
         if self.is_function and len(self.function_parameters):
             for p in self.entity.function.parameters:  # type: ignore[union-attr]
@@ -570,7 +575,7 @@ class ODataQuery:
         headers = {"OData-Version": "4.0", "OData-MaxVersion": "4.0"}
         url = self.odata_url()
         try:
-            res = await _ASYNC_CLIENT.get(url + "?" + qs, headers=headers)
+            res = await get_async_client().get(url + "?" + qs, headers=headers)
         except httpx.HTTPError as ex:
             raise_for_request_error(
                 ex, context=f"OData query {url}", error_cls=ODataError
@@ -602,7 +607,7 @@ class ODataQuery:
         url = self.odata_url()
         logger.debug(f"Fetching OData query from {url}")
         try:
-            res = _CLIENT.get(url + "?" + qs, headers=headers)
+            res = get_client().get(url + "?" + qs, headers=headers)
         except httpx.HTTPError as ex:
             raise_for_request_error(
                 ex, context=f"OData query {url}", error_cls=ODataError

--- a/bcb/sgs/__init__.py
+++ b/bcb/sgs/__init__.py
@@ -22,8 +22,8 @@ import httpx
 import pandas as pd
 
 from bcb.http import (
-    _CLIENT,
-    _ASYNC_CLIENT,
+    get_async_client,
+    get_client,
     raise_for_request_error,
     raise_for_status,
 )
@@ -367,7 +367,7 @@ def get_json(
     url, payload = _get_url_and_payload(code, start, end, last)
     logger.debug(f"Fetching SGS time series code={code} from {url.split('/dados')[0]}")
     try:
-        res = _CLIENT.get(url, params=payload)
+        res = get_client().get(url, params=payload)
     except httpx.HTTPError as ex:
         raise_for_request_error(
             ex, context=f"SGS time series code={code}", error_cls=SGSError
@@ -416,7 +416,7 @@ async def async_get_json(
         f"Fetching SGS time series (async) code={code} from {url.split('/dados')[0]}"
     )
     try:
-        res = await _ASYNC_CLIENT.get(url, params=payload)
+        res = await get_async_client().get(url, params=payload)
     except httpx.HTTPError as ex:
         raise_for_request_error(
             ex, context=f"SGS time series code={code}", error_cls=SGSError

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,5 +1,8 @@
 """Shared HTTP error handling tests."""
 
+import ast
+from pathlib import Path
+
 import httpx
 import pytest
 
@@ -82,3 +85,21 @@ def test_raise_for_request_error_supports_endpoint_specific_exceptions() -> None
             context="OData",
             error_cls=ODataError,
         )
+
+
+def test_feature_modules_do_not_import_private_http_clients() -> None:
+    private_names = {"_CLIENT", "_ASYNC_CLIENT"}
+    violations: list[str] = []
+    for module_path in Path("bcb").rglob("*.py"):
+        if module_path == Path("bcb/http.py"):
+            continue
+        tree = ast.parse(module_path.read_text(), filename=str(module_path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module == "bcb.http":
+                imported = {alias.name for alias in node.names}
+                private_imports = sorted(imported & private_names)
+                if private_imports:
+                    names = ", ".join(private_imports)
+                    violations.append(f"{module_path}: {names}")
+
+    assert violations == []


### PR DESCRIPTION
Closes #34

## Summary
- Replaced direct `_CLIENT` / `_ASYNC_CLIENT` imports in Currency, SGS, and OData with `get_client()` / `get_async_client()`.
- Kept public behavior unchanged while making `bcb.http` the only owner of private client globals.
- Added a regression test that rejects private HTTP client imports from feature modules.

## Verification
- `uv run pytest tests/test_http.py tests/test_async.py tests/test_currency_negative.py tests/test_sgs_negative.py tests/test_odata.py -m "not integration"`
- `uv run pytest -m "not integration"`
- `uv run ruff check bcb/ tests/`
- `uv run ruff format --check bcb/ tests/`
- `uv run mypy bcb/`
