### PR TITLE
Align async currency missing-symbol behavior

### DIFF
--- a/bcb/currency.py
+++ b/bcb/currency.py
@@ -6,7 +6,7 @@ import re
 import threading
 from datetime import date, timedelta
 from io import BytesIO, StringIO
-from typing import Dict, List, Literal, NamedTuple, Union, overload
+from typing import Dict, List, Literal, NamedTuple, NoReturn, Union, overload
 from urllib.parse import urlencode
 
 import httpx
@@ -302,6 +302,11 @@ def _get_currency_id(symbol: str) -> int:
     if matches.empty:
         raise CurrencyNotFoundError(f"Unknown currency symbol: {symbol}")
     return int(matches.max())
+
+
+def _raise_no_valid_currency_symbols(symbols: List[str]) -> NoReturn:
+    requested = ", ".join(symbols) if symbols else "<empty>"
+    raise CurrencyNotFoundError(f"No valid currency symbols found: {requested}")
 
 
 def _fetch_symbol_response(
@@ -620,7 +625,7 @@ def get(
             except CurrencyNotFoundError:
                 pass  # Skip missing currencies
         if not results:
-            raise CurrencyNotFoundError(f"Currency not found: {symbols}")
+            _raise_no_valid_currency_symbols(symbols)
         if len(symbols) == 1:
             return results[symbols[0]]
         return results
@@ -647,7 +652,7 @@ def get(
         else:
             raise ValueError("Unknown side value, use: bid, ask, both")
     else:
-        raise CurrencyNotFoundError(f"Currency not found: {symbols}")
+        _raise_no_valid_currency_symbols(symbols)
 
 
 async def _async_currency_id_list(
@@ -847,24 +852,35 @@ async def async_get(
     if output == "text":
         results: Dict[str, str] = {}
         texts = await asyncio.gather(
-            *[_async_get_symbol_text(symbol, start, end) for symbol in symbols]
+            *[_async_get_symbol_text(symbol, start, end) for symbol in symbols],
+            return_exceptions=True,
         )
         for symbol, text in zip(symbols, texts):
-            if text is not None:
-                results[symbol] = text
+            if isinstance(text, CurrencyNotFoundError):
+                continue
+            if isinstance(text, BaseException):
+                raise text
+            results[symbol] = text
         if not results:
-            raise CurrencyNotFoundError(f"Currency not found: {symbols}")
+            _raise_no_valid_currency_symbols(symbols)
         if len(symbols) == 1:
             return results[symbols[0]]
         return results
 
     dss = await asyncio.gather(
-        *[_async_get_symbol(symbol, start, end) for symbol in symbols]
+        *[_async_get_symbol(symbol, start, end) for symbol in symbols],
+        return_exceptions=True,
     )
-    dss = [df for df in dss if df is not None]
+    valid_dss = []
+    for df in dss:
+        if isinstance(df, CurrencyNotFoundError):
+            continue
+        if isinstance(df, BaseException):
+            raise df
+        valid_dss.append(df)
 
-    if len(dss) > 0:
-        df = pd.concat(dss, axis=1)
+    if len(valid_dss) > 0:
+        df = pd.concat(valid_dss, axis=1)
         if side in ("bid", "ask"):
             dx = df.reorder_levels([1, 0], axis=1).sort_index(axis=1)
             return dx[side]
@@ -878,4 +894,4 @@ async def async_get(
         else:
             raise ValueError("Unknown side value, use: bid, ask, both")
     else:
-        raise CurrencyNotFoundError(f"Currency not found: {symbols}")
+        _raise_no_valid_currency_symbols(symbols)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -10,7 +10,7 @@ import pytest
 
 from bcb import currency, sgs
 from bcb.odata.api import Expectativas
-from bcb.exceptions import BCBRateLimitError, ODataError
+from bcb.exceptions import BCBRateLimitError, CurrencyNotFoundError, ODataError
 from tests.conftest import (
     CURRENCY_ID_LIST_HTML,
     CURRENCY_LIST_CSV,
@@ -30,6 +30,31 @@ PTAX_ID_LIST_URL = re.compile(r".*exibeFormularioConsultaBoletim.*")
 PTAX_CSV_DOWNLOAD_URL = re.compile(r".*www4\.bcb\.gov\.br.*\.csv")
 PTAX_RATE_URL = re.compile(r".*gerarCSVFechamento.*")
 SGS_CODE_URL = re.compile(r".*bcdata\.sgs\..*")
+
+
+def add_currency_base_mocks(httpx_mock):
+    httpx_mock.add_response(
+        url=PTAX_ID_LIST_URL,
+        content=CURRENCY_ID_LIST_HTML,
+        status_code=200,
+        is_reusable=True,
+    )
+    httpx_mock.add_response(
+        url=PTAX_CSV_DOWNLOAD_URL,
+        text=CURRENCY_LIST_CSV,
+        status_code=200,
+        is_reusable=True,
+    )
+
+
+def add_currency_rate_mock(httpx_mock):
+    httpx_mock.add_response(
+        url=PTAX_RATE_URL,
+        text=CURRENCY_RATE_CSV,
+        status_code=200,
+        headers={"Content-Type": "text/csv"},
+        is_reusable=True,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -110,22 +135,8 @@ async def test_async_get_json_rate_limit_raises(httpx_mock):
 
 async def test_async_get_symbol_returns_dataframe(httpx_mock):
     """Test async_get_symbol() returns DataFrame."""
-    httpx_mock.add_response(
-        url=PTAX_ID_LIST_URL,
-        content=CURRENCY_ID_LIST_HTML,
-        status_code=200,
-    )
-    httpx_mock.add_response(
-        url=PTAX_CSV_DOWNLOAD_URL,
-        text=CURRENCY_LIST_CSV,
-        status_code=200,
-    )
-    httpx_mock.add_response(
-        url=PTAX_RATE_URL,
-        text=CURRENCY_RATE_CSV,
-        status_code=200,
-        headers={"Content-Type": "text/csv"},
-    )
+    add_currency_base_mocks(httpx_mock)
+    add_currency_rate_mock(httpx_mock)
     df = await currency._async_get_symbol("USD", START, END)
     assert df is not None
     assert ("USD", "bid") in df.columns
@@ -134,24 +145,62 @@ async def test_async_get_symbol_returns_dataframe(httpx_mock):
 
 async def test_async_get_single_symbol_returns_dataframe(httpx_mock):
     """Test async_get() with single symbol returns DataFrame."""
-    httpx_mock.add_response(
-        url=PTAX_ID_LIST_URL,
-        content=CURRENCY_ID_LIST_HTML,
-        status_code=200,
-    )
-    httpx_mock.add_response(
-        url=PTAX_CSV_DOWNLOAD_URL,
-        text=CURRENCY_LIST_CSV,
-        status_code=200,
-    )
-    httpx_mock.add_response(
-        url=PTAX_RATE_URL,
-        text=CURRENCY_RATE_CSV,
-        status_code=200,
-        headers={"Content-Type": "text/csv"},
-    )
+    add_currency_base_mocks(httpx_mock)
+    add_currency_rate_mock(httpx_mock)
     df = await currency.async_get("USD", START, END)
     assert df is not None
+
+
+async def test_async_get_mixed_valid_invalid_symbols_returns_valid_dataframe(
+    httpx_mock,
+):
+    add_currency_base_mocks(httpx_mock)
+    add_currency_rate_mock(httpx_mock)
+
+    df = await currency.async_get(["USD", "ZAR"], START, END, side="both")
+
+    assert "USD" in df.columns.get_level_values(0)
+    assert "ZAR" not in df.columns.get_level_values(0)
+
+
+async def test_async_get_duplicate_symbols_returns_duplicate_columns(httpx_mock):
+    add_currency_base_mocks(httpx_mock)
+    add_currency_rate_mock(httpx_mock)
+
+    df = await currency.async_get(["USD", "USD"], START, END, side="both")
+
+    assert list(df.columns.get_level_values(0)).count("USD") == 4
+
+
+async def test_async_get_mixed_valid_invalid_text_returns_valid_dict(httpx_mock):
+    add_currency_base_mocks(httpx_mock)
+    add_currency_rate_mock(httpx_mock)
+
+    result = await currency.async_get(["USD", "ZAR"], START, END, output="text")
+
+    assert isinstance(result, dict)
+    assert list(result) == ["USD"]
+    assert "01122020" in result["USD"]
+
+
+async def test_async_get_all_invalid_symbols_raise_clear_error(httpx_mock):
+    add_currency_base_mocks(httpx_mock)
+
+    with pytest.raises(
+        CurrencyNotFoundError,
+        match="No valid currency symbols found: ZAR, ZZ1",
+    ):
+        await currency.async_get(["ZAR", "ZZ1"], START, END)
+
+
+async def test_async_get_all_invalid_text_symbols_raise_clear_error(httpx_mock):
+    add_currency_base_mocks(httpx_mock)
+
+    with pytest.raises(
+        CurrencyNotFoundError,
+        match="No valid currency symbols found: ZAR, ZZ1",
+    ):
+        await currency.async_get(["ZAR", "ZZ1"], START, END, output="text")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_currency.py
+++ b/tests/test_currency.py
@@ -194,14 +194,20 @@ def test_currency_get_invalid_side(httpx_mock):
 def test_currency_get_unknown_symbol_raises(httpx_mock):
     add_id_list_mock(httpx_mock)
     add_currency_list_mock(httpx_mock)
-    with pytest.raises(CurrencyNotFoundError):
+    with pytest.raises(
+        CurrencyNotFoundError,
+        match="No valid currency symbols found: ZAR",
+    ):
         currency.get("ZAR", START, END)
 
 
 def test_currency_get_list_all_unknown_raises(httpx_mock):
     add_id_list_mock(httpx_mock)
     add_currency_list_mock(httpx_mock)
-    with pytest.raises(CurrencyNotFoundError):
+    with pytest.raises(
+        CurrencyNotFoundError,
+        match="No valid currency symbols found: ZAR, ZZ1",
+    ):
         currency.get(["ZAR", "ZZ1"], START, END)
 
 
@@ -247,8 +253,23 @@ def test_currency_get_output_text_unknown_raises(httpx_mock):
     """get('ZAR', output='text') raises CurrencyNotFoundError."""
     add_id_list_mock(httpx_mock)
     add_currency_list_mock(httpx_mock)
-    with pytest.raises(CurrencyNotFoundError):
+    with pytest.raises(
+        CurrencyNotFoundError,
+        match="No valid currency symbols found: ZAR",
+    ):
         currency.get("ZAR", START, END, output="text")
+
+
+def test_currency_get_output_text_mixed_valid_invalid_returns_valid_dict(httpx_mock):
+    add_id_list_mock(httpx_mock)
+    add_currency_list_mock(httpx_mock)
+    add_rate_mock(httpx_mock)
+
+    result = currency.get(["USD", "ZAR"], START, END, output="text")
+
+    assert isinstance(result, dict)
+    assert list(result) == ["USD"]
+    assert "01122020" in result["USD"]
 
 
 def test_currency_get_output_dataframe_is_default(httpx_mock):


### PR DESCRIPTION
## Summary

- keep the existing sync missing-symbol contract as the shared contract
- make async currency calls skip only `CurrencyNotFoundError` results in mixed requests
- preserve propagation for non-not-found API, parsing, and HTTP failures
- use a clearer all-invalid symbol error message
- add sync/async tests for mixed, all-invalid, duplicate, dataframe, and text cases

Fixes #42

## Verification

- `uv run pytest -m "not integration"` (143 passed, 11 deselected)
- `uv run ruff check bcb/ tests/`
- `uv run ruff format --check bcb/ tests/`
- `uv run mypy bcb/`
- `uv run --group docs sphinx-build -b html docs docs/_build/html`
