### PR TITLE
Fix async HTTP client shutdown guidance

### DIFF
--- a/bcb/http.py
+++ b/bcb/http.py
@@ -27,11 +27,16 @@ _CLIENT = httpx.Client(
     follow_redirects=True,
 )
 
-# Shared asynchronous HTTP client (for future async API)
-_ASYNC_CLIENT = httpx.AsyncClient(
-    timeout=DEFAULT_TIMEOUT,
-    follow_redirects=True,
-)
+
+def _make_async_client() -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        timeout=DEFAULT_TIMEOUT,
+        follow_redirects=True,
+    )
+
+
+# Shared asynchronous HTTP client
+_ASYNC_CLIENT = _make_async_client()
 
 
 # Retry decorator for transient failures
@@ -62,7 +67,16 @@ def get_async_client() -> httpx.AsyncClient:
     httpx.AsyncClient
         Shared async client with connection pooling and configured timeout.
     """
+    global _ASYNC_CLIENT
+    if _ASYNC_CLIENT.is_closed:
+        _ASYNC_CLIENT = _make_async_client()
     return _ASYNC_CLIENT
+
+
+async def aclose_async_client() -> None:
+    """Close the shared async client from async code."""
+    if not _ASYNC_CLIENT.is_closed:
+        await _ASYNC_CLIENT.aclose()
 
 
 def close_async_client() -> None:
@@ -74,16 +88,11 @@ def close_async_client() -> None:
     import asyncio
 
     try:
-        loop = asyncio.get_event_loop()
-        if loop.is_running():
-            # If called from async context, schedule closing
-            asyncio.create_task(_ASYNC_CLIENT.aclose())
-        else:
-            # If called from sync context, run the close
-            loop.run_until_complete(_ASYNC_CLIENT.aclose())
+        loop = asyncio.get_running_loop()
     except RuntimeError:
-        # No event loop, create one
-        asyncio.run(_ASYNC_CLIENT.aclose())
+        asyncio.run(aclose_async_client())
+    else:
+        loop.create_task(aclose_async_client())
 
 
 T = TypeVar("T")

--- a/docs/async.rst
+++ b/docs/async.rst
@@ -202,7 +202,9 @@ Performance: Síncrono vs Assíncrono
 Limpeza de Recursos
 -------------------
 
-Para aplicações de longa duração, feche o cliente assíncrono quando terminar:
+Para aplicações de longa duração, feche o cliente assíncrono quando terminar.
+Em código assíncrono, use ``await http.aclose_async_client()`` dentro da
+função principal:
 
 .. code-block:: python
 
@@ -210,13 +212,17 @@ Para aplicações de longa duração, feche o cliente assíncrono quando termina
     from bcb import http
 
     async def main():
-        # ... suas operações assíncronas ...
-        pass
+        try:
+            # ... suas operações assíncronas ...
+            pass
+        finally:
+            await http.aclose_async_client()
 
     asyncio.run(main())
 
-    # Fechar cliente assíncrono
-    asyncio.run(http.close_async_client())
+Em código síncrono, quando não há uma event loop em execução, também é possível
+chamar ``http.close_async_client()`` diretamente após terminar as operações
+assíncronas.
 
 Limitações
 ----------

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,5 +1,6 @@
 """Shared HTTP error handling tests."""
 
+import asyncio
 import ast
 from pathlib import Path
 
@@ -14,6 +15,7 @@ from bcb.exceptions import (
     ODataError,
     SGSError,
 )
+from bcb import http as http_module
 from bcb.http import raise_for_request_error, raise_for_status
 
 
@@ -103,3 +105,67 @@ def test_feature_modules_do_not_import_private_http_clients() -> None:
                     violations.append(f"{module_path}: {names}")
 
     assert violations == []
+
+
+class FakeAsyncClient:
+    def __init__(self, *, is_closed: bool = False) -> None:
+        self.is_closed = is_closed
+        self.close_count = 0
+
+    async def aclose(self) -> None:
+        self.is_closed = True
+        self.close_count += 1
+
+
+def test_get_async_client_recreates_closed_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    closed_client = FakeAsyncClient(is_closed=True)
+    replacement_client = FakeAsyncClient()
+    monkeypatch.setattr(http_module, "_ASYNC_CLIENT", closed_client)
+    monkeypatch.setattr(http_module, "_make_async_client", lambda: replacement_client)
+
+    assert http_module.get_async_client() is replacement_client
+
+
+def test_close_async_client_runs_from_sync_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeAsyncClient()
+    monkeypatch.setattr(http_module, "_ASYNC_CLIENT", client)
+
+    http_module.close_async_client()
+
+    assert client.is_closed
+    assert client.close_count == 1
+
+
+def test_documented_async_shutdown_example_runs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeAsyncClient()
+    monkeypatch.setattr(http_module, "_ASYNC_CLIENT", client)
+
+    async def main() -> None:
+        await http_module.aclose_async_client()
+
+    asyncio.run(main())
+
+    assert client.is_closed
+    assert client.close_count == 1
+
+
+def test_close_async_client_schedules_from_running_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeAsyncClient()
+    monkeypatch.setattr(http_module, "_ASYNC_CLIENT", client)
+
+    async def main() -> None:
+        http_module.close_async_client()
+        await asyncio.sleep(0)
+
+    asyncio.run(main())
+
+    assert client.is_closed
+    assert client.close_count == 1


### PR DESCRIPTION
## Summary

- add `http.aclose_async_client()` for explicit async shutdown
- keep `http.close_async_client()` usable from sync code and compatible with running-loop callers
- recreate the shared async client after it has been closed
- update async docs so the shutdown example actually runs
- add sync and async lifecycle tests

Fixes #40

## Verification

- `uv run pytest -m "not integration"` (147 passed, 11 deselected)
- `uv run ruff check bcb/ tests/`
- `uv run ruff format --check bcb/ tests/`
- `uv run mypy bcb/`
- `uv run --group docs sphinx-build -b html docs docs/_build/html`
