### PR TITLE
Strengthen OData and HTTP test coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ omit = ["tests/*"]
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 70
+fail_under = 75
 
 [tool.mypy]
 python_version = "3.10"

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -6,6 +6,7 @@ Tests for async_get() functions in sgs, currency, and odata modules.
 import re
 from datetime import datetime
 
+import httpx
 import pytest
 
 from bcb import currency, sgs
@@ -304,6 +305,29 @@ async def test_odata_query_async_status_error_raises(httpx_mock):
     ep = api.get_endpoint("ExpectativasMercadoAnuais")
 
     with pytest.raises(ODataError, match="OData query"):
+        await ep.query().limit(1).async_text()
+
+
+async def test_odata_query_async_transport_error_raises(httpx_mock):
+    httpx_mock.add_response(
+        url="https://olinda.bcb.gov.br/olinda/servico/Expectativas/versao/v1/odata/",
+        text=ODATA_SERVICE_ROOT_JSON,
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        url="https://olinda.bcb.gov.br/olinda/servico/Expectativas/versao/v1/odata/$metadata",
+        content=ODATA_METADATA_XML,
+        status_code=200,
+    )
+    httpx_mock.add_exception(
+        httpx.ConnectError("network down"),
+        url=re.compile(r".*ExpectativasMercadoAnuais.*"),
+    )
+
+    api = Expectativas()
+    ep = api.get_endpoint("ExpectativasMercadoAnuais")
+
+    with pytest.raises(ODataError, match="OData query.*network down"):
         await ep.query().limit(1).async_text()
 
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -28,6 +28,10 @@ def test_raise_for_status_allows_expected_status() -> None:
     raise_for_status(make_response(200), context="Example")
 
 
+def test_raise_for_status_allows_expected_status_tuple() -> None:
+    raise_for_status(make_response(202), context="Example", expected_status=(200, 202))
+
+
 @pytest.mark.parametrize(
     ("status_code", "error_cls"),
     [
@@ -61,6 +65,17 @@ def test_raise_for_status_supports_endpoint_specific_exceptions() -> None:
             server_error_cls=SGSError,
             server_error_message="SGS unavailable",
         )
+
+
+def test_raise_for_status_uses_custom_rate_limit_message() -> None:
+    with pytest.raises(BCBRateLimitError, match="Slow down") as exc_info:
+        raise_for_status(
+            make_response(429),
+            context="Example",
+            rate_limit_message="Slow down",
+        )
+
+    assert exc_info.value.status_code == 429
 
 
 @pytest.mark.parametrize(
@@ -169,3 +184,15 @@ def test_close_async_client_schedules_from_running_loop(
 
     assert client.is_closed
     assert client.close_count == 1
+
+
+def test_with_retry_decorator_returns_successful_result() -> None:
+    calls: list[int] = []
+
+    @http_module.with_retry
+    def sample(value: int) -> int:
+        calls.append(value)
+        return value * 2
+
+    assert sample(21) == 42
+    assert calls == [21]

--- a/tests/test_odata.py
+++ b/tests/test_odata.py
@@ -6,7 +6,14 @@ import pandas as pd
 import pytest
 
 from bcb.odata.api import Expectativas
-from bcb.odata.framework import ODataProperty, ODataPropertyFilter, ODataPropertyOrderBy
+from bcb.odata.framework import (
+    ODataParameter,
+    ODataProperty,
+    ODataPropertyFilter,
+    ODataPropertyOrderBy,
+    ODataService,
+    str_types,
+)
 from bcb.exceptions import ODataError
 from tests.conftest import (
     ODATA_SERVICE_ROOT_JSON,
@@ -22,6 +29,41 @@ EXPECTATIVAS_METADATA_URL = (
     "https://olinda.bcb.gov.br/olinda/servico/Expectativas/versao/v1/odata/$metadata"
 )
 ENTITY_URL_PATTERN = re.compile(r".*ExpectativasMercadoAnuais.*")
+FUNCTION_METADATA_XML = b"""<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="TestModel" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Cotacao">
+        <Property Name="Moeda" Type="Edm.String"/>
+        <Property Name="Data" Type="Edm.Date"/>
+        <Property Name="CotacaoCompra" Type="Edm.Decimal"/>
+      </EntityType>
+      <Function Name="CotacaoMoedaPeriodo">
+        <Parameter Name="moeda" Type="Edm.String" Nullable="false"/>
+        <Parameter Name="dataInicial" Type="Edm.String" Nullable="false"/>
+        <Parameter Name="limite" Type="Edm.Int32" Nullable="false"/>
+        <ReturnType Type="Collection(TestModel.Cotacao)"/>
+      </Function>
+      <EntityContainer Name="Container">
+        <EntitySet Name="CotacoesMoedaPeriodo" EntityType="TestModel.Cotacao"/>
+        <FunctionImport Name="CotacaoMoedaPeriodo"
+                        Function="TestModel.CotacaoMoedaPeriodo"
+                        EntitySet="TestModel.CotacoesMoedaPeriodo"/>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>"""
+
+FUNCTION_SERVICE_ROOT_JSON = """{
+  "@odata.context": "https://example.test/odata/$metadata",
+  "value": [
+    {"name": "CotacaoMoedaPeriodo", "kind": "FunctionImport", "url": "CotacaoMoedaPeriodo"}
+  ]
+}"""
+
+FUNCTION_BASE_URL = "https://example.test/odata/"
+FUNCTION_METADATA_URL = "https://example.test/odata/$metadata"
+FUNCTION_URL_PATTERN = re.compile(r".*CotacaoMoedaPeriodo.*")
 
 
 def add_service_mocks(httpx_mock):
@@ -34,6 +76,19 @@ def add_service_mocks(httpx_mock):
     httpx_mock.add_response(
         url=EXPECTATIVAS_METADATA_URL,
         content=ODATA_METADATA_XML,
+        status_code=200,
+    )
+
+
+def add_function_service_mocks(httpx_mock):
+    httpx_mock.add_response(
+        url=FUNCTION_BASE_URL,
+        text=FUNCTION_SERVICE_ROOT_JSON,
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        url=FUNCTION_METADATA_URL,
+        content=FUNCTION_METADATA_XML,
         status_code=200,
     )
 
@@ -108,6 +163,45 @@ def test_service_root_missing_required_fields_raises_odata_error(httpx_mock):
         Expectativas()
 
 
+def test_service_root_value_must_be_list(httpx_mock):
+    httpx_mock.add_response(
+        url=EXPECTATIVAS_BASE_URL,
+        text=(
+            '{"@odata.context": "'
+            + EXPECTATIVAS_METADATA_URL
+            + '", "value": {"name": "ExpectativasMercadoAnuais"}}'
+        ),
+        status_code=200,
+    )
+
+    with pytest.raises(ODataError, match="value.*list"):
+        Expectativas()
+
+
+def test_service_root_value_items_must_be_objects(httpx_mock):
+    httpx_mock.add_response(
+        url=EXPECTATIVAS_BASE_URL,
+        text='{"@odata.context": "'
+        + EXPECTATIVAS_METADATA_URL
+        + '", "value": ["bad"]}',
+        status_code=200,
+    )
+
+    with pytest.raises(ODataError, match="value.*objects"):
+        Expectativas()
+
+
+def test_service_root_context_must_be_string(httpx_mock):
+    httpx_mock.add_response(
+        url=EXPECTATIVAS_BASE_URL,
+        text='{"@odata.context": 123, "value": []}',
+        status_code=200,
+    )
+
+    with pytest.raises(ODataError, match="@odata.context.*string"):
+        Expectativas()
+
+
 def test_metadata_status_error_raises_odata_error(httpx_mock):
     httpx_mock.add_response(
         url=EXPECTATIVAS_BASE_URL,
@@ -156,6 +250,50 @@ def test_metadata_missing_schema_raises_odata_error(httpx_mock):
         Expectativas()
 
 
+def test_metadata_invalid_structure_raises_odata_error(httpx_mock):
+    httpx_mock.add_response(
+        url=EXPECTATIVAS_BASE_URL,
+        text=ODATA_SERVICE_ROOT_JSON,
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        url=EXPECTATIVAS_METADATA_URL,
+        text="""<?xml version="1.0"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm"/>
+  </edmx:DataServices>
+</edmx:Edmx>""",
+        status_code=200,
+    )
+
+    with pytest.raises(ODataError, match="invalid structure"):
+        Expectativas()
+
+
+def test_service_reuses_cached_metadata(httpx_mock):
+    httpx_mock.add_response(
+        url=EXPECTATIVAS_BASE_URL,
+        text=ODATA_SERVICE_ROOT_JSON,
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        url=EXPECTATIVAS_METADATA_URL,
+        content=ODATA_METADATA_XML,
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        url=EXPECTATIVAS_BASE_URL,
+        text=ODATA_SERVICE_ROOT_JSON,
+        status_code=200,
+    )
+
+    first = Expectativas()
+    second = Expectativas()
+
+    assert second.service.metadata is first.service.metadata
+
+
 def test_query_status_error_raises_odata_error(httpx_mock):
     add_service_mocks(httpx_mock)
     httpx_mock.add_response(
@@ -201,6 +339,20 @@ def test_query_missing_value_raises_odata_error(httpx_mock):
         ep.query().limit(1).collect()
 
 
+def test_query_transport_error_raises_odata_error(httpx_mock):
+    add_service_mocks(httpx_mock)
+    httpx_mock.add_exception(
+        httpx.ConnectError("network down"),
+        url=ENTITY_URL_PATTERN,
+    )
+
+    api = Expectativas()
+    ep = api.get_endpoint("ExpectativasMercadoAnuais")
+
+    with pytest.raises(ODataError, match="OData query.*network down"):
+        ep.query().limit(1).text()
+
+
 # ---------------------------------------------------------------------------
 # ODataProperty operator overloading
 # ---------------------------------------------------------------------------
@@ -241,6 +393,11 @@ def test_int_property_filter_formats_ints():
     assert str(prazo == "12") == "Prazo eq 12"
 
 
+def test_boolean_property_filter_formats_booleans():
+    ativo = ODataProperty(Name="Ativo", Type="Edm.Boolean")
+    assert str(ativo == True) == "Ativo eq true"  # noqa: E712
+
+
 @pytest.mark.parametrize(
     ("prop", "value", "message"),
     [
@@ -266,6 +423,22 @@ def test_property_orderby(httpx_mock):
     assert isinstance(ep.Mediana.asc(), ODataPropertyOrderBy)
     assert str(ep.Mediana.asc()) == "Mediana asc"
     assert str(ep.Mediana.desc()) == "Mediana desc"
+
+
+def test_parameter_formatting_and_type_mapping():
+    decimal_param = ODataParameter(Name="valor", Type="Edm.Decimal")
+    int_param = ODataParameter(Name="prazo", Type="Edm.Int32", Nullable="false")
+    string_param = ODataParameter(Name="moeda", Type="Edm.String", Nullable="true")
+    bool_param = ODataParameter(Name="ativo", Type="Edm.Boolean")
+
+    assert decimal_param.format("1.25") == "1.25"
+    assert int_param.format("12") == "12"
+    assert string_param.format("USD") == "'USD'"
+    assert bool_param.format(True) == "'True'"
+    assert int_param.required
+    assert not string_param.required
+    assert str_types("Edm.TimeOfDay") == "datetime"
+    assert str_types("Edm.Guid") == "Edm.Guid"
 
 
 # ---------------------------------------------------------------------------
@@ -313,6 +486,100 @@ def test_endpoint_get_shortcut(httpx_mock):
     df = ep.get(limit=1)
     assert isinstance(df, pd.DataFrame)
     assert len(df) == 1
+
+
+def test_query_serializes_filter_orderby_select_and_pagination(httpx_mock):
+    add_service_mocks(httpx_mock)
+    httpx_mock.add_response(
+        url=ENTITY_URL_PATTERN,
+        text=ODATA_QUERY_RESPONSE_JSON,
+        status_code=200,
+    )
+    api = Expectativas()
+    entity = api.service["ExpectativasMercadoAnuais"]
+
+    query = (
+        api.service.query(entity)
+        .filter(entity.Indicador == "Focus's IPCA", entity.Mediana > 4)
+        .orderby(entity.Data.desc())
+        .select(entity.Indicador, entity.Mediana)
+        .limit(5)
+        .skip(10)
+    )
+    data = query.collect()
+
+    request = httpx_mock.get_requests()[-1]
+    assert data["value"][0]["Indicador"] == "IPCA"
+    assert request.url.params["$format"] == "json"
+    assert (
+        request.url.params["$filter"]
+        == "Indicador eq 'Focus''s IPCA' and Mediana gt 4.0"
+    )
+    assert request.url.params["$orderby"] == "Data desc"
+    assert request.url.params["$select"] == "Indicador,Mediana"
+    assert request.url.params["$top"] == "5"
+    assert request.url.params["$skip"] == "10"
+
+
+def test_query_reset_clears_filters_ordering_and_pagination(httpx_mock):
+    add_service_mocks(httpx_mock)
+    api = Expectativas()
+    entity = api.service["ExpectativasMercadoAnuais"]
+    query = (
+        api.service.query(entity)
+        .filter(entity.Indicador == "IPCA")
+        .orderby(entity.Data.asc())
+        .limit(5)
+    )
+
+    query.reset()
+
+    assert query._build_parameters() == {"$format": "json"}
+
+
+def test_function_import_query_serialization(httpx_mock):
+    add_function_service_mocks(httpx_mock)
+    httpx_mock.add_response(
+        url=FUNCTION_URL_PATTERN,
+        text=ODATA_QUERY_RESPONSE_JSON,
+        status_code=200,
+    )
+    service = ODataService(FUNCTION_BASE_URL)
+    function_import = service["CotacaoMoedaPeriodo"]
+
+    result = (
+        service.query(function_import)
+        .parameters(moeda="USD", dataInicial="01-01-2020", limite=5)
+        .limit(1)
+        .text()
+    )
+
+    request = httpx_mock.get_requests()[-1]
+    assert "IPCA" in result
+    assert (
+        str(request.url).split("?", 1)[0]
+        == "https://example.test/odata/CotacaoMoedaPeriodo(moeda=@moeda,dataInicial=@dataInicial,limite=@limite)"
+    )
+    assert request.url.params["@moeda"] == "'USD'"
+    assert request.url.params["@dataInicial"] == "'01-01-2020'"
+    assert request.url.params["@limite"] == "5"
+    assert request.url.params["$top"] == "1"
+
+
+def test_function_import_missing_required_parameter_raises(httpx_mock):
+    add_function_service_mocks(httpx_mock)
+    service = ODataService(FUNCTION_BASE_URL)
+
+    with pytest.raises(ODataError, match="Parameter not set: moeda"):
+        service.query(service["CotacaoMoedaPeriodo"]).text()
+
+
+def test_function_import_unknown_parameter_raises(httpx_mock):
+    add_function_service_mocks(httpx_mock)
+    service = ODataService(FUNCTION_BASE_URL)
+
+    with pytest.raises(ODataError, match="Unknown parameter"):
+        service.query(service["CotacaoMoedaPeriodo"]).parameters(unknown="x")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add deterministic HTTP tests for expected status tuples, custom rate-limit messages, and retry decoration
- add OData service/metadata validation, metadata cache, function-import, query serialization, and sync/async transport-error tests
- raise the coverage gate from 70% to 75%

Fixes #35

## Coverage
- `uv run pytest --cov=bcb --cov-report=term-missing -m "not integration"`
- total coverage: 86.88%
- `bcb/http.py`: 100%
- `bcb/odata/framework.py`: 85%

## Verification
- `uv run pytest -m "not integration"` (185 passed, 11 deselected)
- `uv run ruff check bcb/ tests/`
- `uv run ruff format --check bcb/ tests/`
- `uv run mypy bcb/`
- `uv run --group docs sphinx-build -b html docs docs/_build/html`
